### PR TITLE
Add frameCount to glsl.loop and restart() to restart time

### DIFF
--- a/swissgl.js
+++ b/swissgl.js
@@ -835,9 +835,12 @@ function SwissGL(canvas_gl) {
             canvas.width = w; canvas.height = h;
         }
     }
+    let frameCount = 0;
     glsl.loop = callback=>{
+        frameCount = 0;
         const frameFunc = time=>{
-            const res = callback({glsl, time:time/1000.0});
+            const res = callback({glsl, time:time/1000.0, frameCount});
+            frameCount++;
             if (res != 'stop') requestAnimationFrame(frameFunc);
         };
         requestAnimationFrame(frameFunc);

--- a/swissgl.js
+++ b/swissgl.js
@@ -836,9 +836,15 @@ function SwissGL(canvas_gl) {
         }
     }
     let frameCount = 0;
+    let baseTime = 0;
+    glsl.restart = () => {
+      baseTime = performance.now();
+      frameCount = 0;
+    };
     glsl.loop = callback=>{
         frameCount = 0;
         const frameFunc = time=>{
+            time = time - baseTime;
             const res = callback({glsl, time:time/1000.0, frameCount});
             frameCount++;
             if (res != 'stop') requestAnimationFrame(frameFunc);


### PR DESCRIPTION
Looking at the examples in https://znah.net/alife24 I've noticed that some rely on frameCount to perform initialization.

I like how `time` is available from `glsl.loop({time} => ...` so I propose to also add frameCount i.e. `glsl.loop({time, frameCount} => ...`
This can also be used to easily measure FPS e.g. ```fpsDisplay.textContent = `FPS: ${Math.round(frameCount / time)}`;```

Additionally, the fact that time is set by the `requestAnimationFrame` function makes resetting time tricky so I propose adding `glsl.restart()` that resets both time and frameCount to 0.


Note: The proposed changes effectively move  the code used in the above [link](https://znah.net/alife24) inside swissgl itself i.e.
```javascript
let frameCount = 0;
canvas.onclick = ()=>{
	frameCount = 0;
}
glsl.loop(args=>{
	if (frameFunc) {
		glsl.adjustCanvas();
		try {
			frameFunc({...args, frameCount});
			frameCount++;
		...
});
```
</details>